### PR TITLE
Remove long-press hide functionality

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -20,7 +20,7 @@ export default function Game() {
     resetMatch,
     isReady,
   } = useGameStore();
-  const { config, toggleFood } = useConfigStore();
+  const { config } = useConfigStore();
 
   const [selectWinner, setSelectWinner] = useState<"p1" | "p2" | null>(null);
 
@@ -74,9 +74,6 @@ export default function Game() {
     return (
       <TouchableOpacity
         activeOpacity={0.9}
-        onLongPress={() => {
-          if (f) toggleFood(f.id, false);
-        }}
         style={s.card}
       >
         <Text style={s.cardHand}>{label}</Text>
@@ -84,7 +81,6 @@ export default function Game() {
           <>
             <Text style={s.cardName}>{f.name}</Text>
             <Text style={s.cardPts}>+{item!.points} pt</Text>
-            <Text style={s.cardHelp}>長押しで非表示（次ラウンドから反映）</Text>
           </>
         ) : (
           <Text style={s.none}>候補なし</Text>
@@ -222,7 +218,6 @@ const s = StyleSheet.create({
   cardHand: { fontWeight: "700", marginBottom: 6 },
   cardName: { fontSize: 16, fontWeight: "700" },
   cardPts: { marginTop: 4, color: "#555" },
-  cardHelp: { marginTop: 6, fontSize: 12, color: "#6b7280" },
   none: { color: "#999", marginTop: 16 },
   row: { flexDirection: "row", gap: 8, marginTop: 16 },
   bigBtn: {

--- a/src/logic/preview.ts
+++ b/src/logic/preview.ts
@@ -10,7 +10,6 @@ export type PreviewItem = {
 export type RoundPreview = {
   seed: string;
   byHand: Partial<Record<Pool, PreviewItem>>;
-  onHide?: (foodId: string) => void; // 長押しで非表示 → 次ラウンドから反映
 };
 
 function pickDistinct3(

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -52,12 +52,6 @@ export const useGameStore = create<GameState>((set, get) => ({
     const cfg = useConfigStore.getState().config!;
     const seed = `${Date.now()}-${Math.random()}`;
     const pv = makePreview(seed, cfg);
-    // 対戦画面から長押し非表示 → configStore を更新
-    pv.onHide = (foodId: string) => {
-      const cs = useConfigStore.getState();
-      cs.toggleFood(foodId, false);
-      // 再生成（当該ラウンドは固定が理想だが「非表示」は次ラウンドから効く想定でもOK）
-    };
     set({ preview: pv });
   },
 


### PR DESCRIPTION
## Summary
- Remove ability to hide food cards with long press in the game screen
- Drop unused long-press onHide hook from preview and store logic

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'expo-status-bar' and type errors)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e9bc4eab8832793650d4695a8e4d7