### PR TITLE
Ensure game reset and clarify inventory points

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -31,8 +31,10 @@ export default function Game() {
       ]);
       return;
     }
-    startMatch(config);
-  }, [config]);
+    if (!isReady) {
+      startMatch(config);
+    }
+  }, [config, isReady]);
 
   useEffect(() => {
     if (isReady) newPreview();
@@ -162,7 +164,17 @@ export default function Game() {
         <TouchableOpacity
           style={s.secondary}
           onPress={() => {
-            resetMatch();
+            Alert.alert("リセットしますか？", "試合を最初からやり直します", [
+              { text: "キャンセル", style: "cancel" },
+              {
+                text: "リセット",
+                style: "destructive",
+                onPress: () => {
+                  startMatch(config!);
+                  newPreview();
+                },
+              },
+            ]);
           }}
         >
           <Text style={s.secondaryTxt}>リセット</Text>

--- a/app/inventory.tsx
+++ b/app/inventory.tsx
@@ -90,6 +90,7 @@ export default function Inventory() {
               style={s.pointInput}
               keyboardType="numeric"
             />
+            <Text style={s.pointLabel}>点</Text>
           </View>
         )}
         renderHiddenItem={({ item }) => (
@@ -153,6 +154,7 @@ const s = StyleSheet.create({
   },
   nameInput: { flex: 1, fontWeight: "700" },
   pointInput: { width: 40, marginLeft: 8, textAlign: "right" },
+  pointLabel: { marginLeft: 4 },
   hiddenRow: {
     flex: 1,
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- Label inventory point inputs to clarify their meaning
- Avoid restarting match when returning from inventory
- Confirm before resetting a match and fully restart on acceptance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eb0e627a0832780fb0f1aaac50873