### PR TITLE
feat: integrate AdMob interstitial and native ads

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,13 @@
 import { Stack } from "expo-router";
 import { StatusBar } from "react-native";
 import "react-native-gesture-handler";
-import React from "react";
+import React, { useEffect } from "react";
+import mobileAds from "react-native-google-mobile-ads";
 
 export default function RootLayout() {
+  useEffect(() => {
+    mobileAds().initialize();
+  }, []);
   return (
     <>
       <StatusBar barStyle="dark-content" />

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-swipe-list-view": "^3.2.9",
+    "react-native-google-mobile-ads": "^13.8.0",
     "seedrandom": "^3.0.5",
     "zod": "^3.23.8",
     "zustand": "^4.5.2"


### PR DESCRIPTION
## Summary
- initialize Google Mobile Ads at app start
- show interstitial ad after a game ends before displaying results
- render a native advanced ad at the top of the game screen
- document where to input production AdMob unit IDs for interstitial and native ads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ec14e49708327acbf0abc2c24dac9